### PR TITLE
Use current directory as fallback in Launcher

### DIFF
--- a/launcher/src/CmderLauncher.cpp
+++ b/launcher/src/CmderLauncher.cpp
@@ -433,7 +433,25 @@ cmderOptions GetOption()
 			cmderOptions.error = true;
 		}
 	}
-
+	
+	if (cmderOptions.cmderStart == L"") 
+	{
+		TCHAR currentWorkingDir[MAX_PATH];
+		if (GetCurrentDirectory(MAX_PATH, currentWorkingDir) == 0)
+		{
+			MessageBox(NULL, L"Failed querying current directory", MB_TITLE, MB_OK);
+			cmderOptions.error = true;
+		}
+		else if (PathFileExists(currentWorkingDir)) 
+		{
+			cmderOptions.cmderStart = currentWorkingDir;
+		}
+		else 
+		{
+			MessageBox(NULL, currentWorkingDir, L"Current working diectory doses not exist!", MB_OK);
+		}
+	}
+	
 	LocalFree(szArgList);
 
 	return cmderOptions;


### PR DESCRIPTION
use the Launcher's current directory if start up dir isn't passed as argument.

Fixes #1414 which can't be resolved using `user-profile` scripts anymore since `%ConEmuWorkDir%` isn't set.